### PR TITLE
Increased max combat distance

### DIFF
--- a/UI/Main.lua
+++ b/UI/Main.lua
@@ -1278,7 +1278,7 @@ local Options = {
                         desc = "At what range can you attack the mobs?",
                         width = "full",
                         min = 3,
-                        max = 35,
+                        max = 45,
                         step = 1,
                         get = function()
                             return DMW.Settings.profile.Grind.CombatDistance


### PR DESCRIPTION
Some classes have spell range modifiers. For example, mage talent "Flame Throwing" https://classic.wowhead.com/spell=12353/flame-throwing